### PR TITLE
[v1.0.0] Profile and optimize the formatters

### DIFF
--- a/.github/workflows/mira-tox.yml
+++ b/.github/workflows/mira-tox.yml
@@ -1,0 +1,24 @@
+name: mira-tox
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  mira-tox:
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", pypy3]
+        os: [windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install tox
+        run: python -m pip install --upgrade tox virtualenv setuptools pip
+      - name: run tox
+        run: tox -e py

--- a/src/miroslava/config/internal.py
+++ b/src/miroslava/config/internal.py
@@ -18,6 +18,8 @@ HOME_PATH = _os.expanduser("~")
 ROOT_PATH = _os.join(HOME_PATH, ROOT)
 LOGGER_PATH = _os.join(ROOT_PATH, LOGGED_USER, LOGS)
 
+ENCODING = "utf-8"
+
 DEFAULT_DATETIME_FMT = "%Y-%m-%d %H:%M:%S"
 LOGGER_DATETIME_FMT = "%b %d, %Y %H:%M:%S"
 

--- a/src/miroslava/config/internal.py
+++ b/src/miroslava/config/internal.py
@@ -6,6 +6,8 @@ import sys
 
 OS = sys.platform
 WINDOWS_OS = OS == "win32"
+# NOTE: Tox breaks `getpass.getuser` on Windows
+# https://github.com/tox-dev/tox/issues/1455
 LOGGED_USER = getpass.getuser()
 
 ROOT = ".miroslava"

--- a/src/miroslava/utils/logger.py
+++ b/src/miroslava/utils/logger.py
@@ -12,6 +12,8 @@ from miroslava.config.internal import (
 )
 from miroslava.utils.common import Singleton, TTYPalette
 
+__all__ = []
+
 # NOTE: Most of the docstring is referenced from the original logging
 # module since this logger does not intent to change the behavior of
 # the underlying implementation but rather adds some level of simplicity


### PR DESCRIPTION
Added a note regarding the recent GitHub action failures because of the `getpass.getuser` breaking on windows.
Link to the issue is added for a quick reference. Any open PRs due to this should be closed by the maintainers.

Deprecate use of regex for extracting path length from `LOGGER_MSG_FMT` over a limit constant. This reduced the function calls exponentially.

Remove `__all__` as the module does not intent to export the formatters.

Updated and reorganized all the docstrings to keep updated with latest modifications. This fixes the typos and the internal references.
Fix note regarding the docstrings and module's intent.

Add support for singleton design pattern in the formatters. Fix class docstrings and typos.
Attribute names have been changed to make more sense and easy to understand. Formatter class now uses full pathname instead of abspath of the current directory.
Fixed `pathname` hack by setting a new `caller` attribute to LogRecord object.

Added support for positional-only arguments in `StreamHandler`. This makes the intent of coloring more clear and enforces users to specify what should be colorized.